### PR TITLE
Add hooks and entry point

### DIFF
--- a/src/hooks/use-core.ts
+++ b/src/hooks/use-core.ts
@@ -1,0 +1,118 @@
+/**
+ * useCore フック - Core プロセスとの接続管理
+ *
+ * wn-core の子プロセスを起動し、JSON-RPC イベントを
+ * AppState の reducer にディスパッチする。
+ */
+
+import { useReducer, useEffect, useRef, useCallback } from 'react'
+import { createCoreClient } from '../rpc/client.js'
+import type { CoreClient } from '../rpc/client.js'
+import type { CoreEvent } from '../rpc/types.js'
+import { appReducer } from '../state/reducer.js'
+import type { AppAction } from '../state/reducer.js'
+import type { AppState } from '../state/types.js'
+import { INITIAL_STATE } from '../state/types.js'
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface UseCoreOptions {
+  readonly corePath: string
+  readonly coreArgs?: readonly string[]
+}
+
+interface UseCoreResult {
+  readonly state: AppState
+  readonly sendInput: (text: string) => Promise<void>
+  readonly sendAbort: () => Promise<void>
+}
+
+// =============================================================================
+// mapEventToAction - CoreEvent → AppAction 変換
+// =============================================================================
+
+/**
+ * CoreEvent を AppAction にマッピングする純粋関数。
+ * テスト容易性のために export する。
+ */
+export function mapEventToAction(event: CoreEvent): AppAction {
+  switch (event.type) {
+    case 'response':
+      return { type: 'RESPONSE', content: event.content }
+
+    case 'toolStart':
+      return { type: 'TOOL_START', name: event.name, args: event.args }
+
+    case 'toolEnd':
+      return { type: 'TOOL_END', name: event.name, result: event.result }
+
+    case 'stateChange':
+      return { type: 'STATE_CHANGE', state: event.state }
+
+    case 'log':
+      return { type: 'LOG', level: event.level, message: event.message }
+  }
+}
+
+// =============================================================================
+// useCore フック
+// =============================================================================
+
+/**
+ * Core プロセスとの接続を管理するカスタムフック。
+ *
+ * - useReducer で AppState を管理
+ * - useEffect で CoreClient を作成し、イベントをディスパッチ
+ * - アンマウント時に CoreClient を kill してクリーンアップ
+ */
+export function useCore(options: UseCoreOptions): UseCoreResult {
+  const { corePath, coreArgs } = options
+  const [state, dispatch] = useReducer(appReducer, INITIAL_STATE)
+  const clientRef = useRef<CoreClient | null>(null)
+
+  useEffect(() => {
+    const client = createCoreClient({
+      corePath,
+      coreArgs,
+      onEvent: (event: CoreEvent) => {
+        const action = mapEventToAction(event)
+        dispatch(action)
+      },
+      onExit: (code: number | null) => {
+        dispatch({
+          type: 'DISCONNECTED',
+          error: `Process exited with code ${String(code)}`,
+        })
+      },
+    })
+
+    clientRef.current = client
+    dispatch({ type: 'CONNECTED' })
+
+    return () => {
+      client.kill()
+      clientRef.current = null
+    }
+  }, [corePath, coreArgs])
+
+  const sendInput = useCallback(async (text: string): Promise<void> => {
+    // UI に即座に反映するためにまず USER_INPUT をディスパッチ
+    dispatch({ type: 'USER_INPUT', text })
+
+    const client = clientRef.current
+    if (client) {
+      await client.sendInput(text)
+    }
+  }, [])
+
+  const sendAbort = useCallback(async (): Promise<void> => {
+    const client = clientRef.current
+    if (client) {
+      await client.sendAbort()
+    }
+  }, [])
+
+  return { state, sendInput, sendAbort }
+}

--- a/src/hooks/use-input.ts
+++ b/src/hooks/use-input.ts
@@ -1,0 +1,60 @@
+/**
+ * useInput フック - 入力エリアの制御
+ *
+ * テキスト入力の状態管理と、agentState に基づく
+ * 無効化制御を提供する。
+ */
+
+import { useState, useCallback } from 'react'
+import type { AgentState } from '../rpc/types.js'
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface UseInputOptions {
+  readonly agentState: AgentState
+  readonly onSubmit: (text: string) => Promise<void>
+}
+
+interface UseInputResult {
+  readonly value: string
+  readonly onChange: (value: string) => void
+  readonly handleSubmit: (value: string) => void
+  readonly isDisabled: boolean
+}
+
+// =============================================================================
+// useInput フック
+// =============================================================================
+
+/**
+ * 入力エリアの制御を行うカスタムフック。
+ *
+ * - agentState が 'thinking' または 'tool_running' のとき入力を無効化
+ * - handleSubmit で onSubmit を呼び出し、value をリセット
+ * - 空文字列の submit は無視
+ */
+export function useInput(options: UseInputOptions): UseInputResult {
+  const { agentState, onSubmit } = options
+  const [value, setValue] = useState('')
+
+  const isDisabled = agentState === 'thinking' || agentState === 'tool_running'
+
+  const onChange = useCallback((newValue: string): void => {
+    setValue(newValue)
+  }, [])
+
+  const handleSubmit = useCallback(
+    (text: string): void => {
+      if (isDisabled || text.length === 0) {
+        return
+      }
+      void onSubmit(text)
+      setValue('')
+    },
+    [isDisabled, onSubmit],
+  )
+
+  return { value, onChange, handleSubmit, isDisabled }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * wn-tui エントリポイント
+ *
+ * CLI 引数をパースし、wn-core プロセスを起動して
+ * Ink ベースの TUI をレンダリングする。
+ */
+
+import React from 'react'
+import { render } from 'ink'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
+import { useCore } from './hooks/use-core.js'
+import { useInput } from './hooks/use-input.js'
+import { App } from './components/App.js'
+
+// =============================================================================
+// WnApp コンポーネント
+// =============================================================================
+
+interface WnAppProps {
+  readonly corePath: string
+  readonly coreArgs?: readonly string[]
+}
+
+function WnApp({ corePath, coreArgs }: WnAppProps): React.ReactElement {
+  const { state, sendInput, sendAbort } = useCore({ corePath, coreArgs })
+  const { value, onChange, handleSubmit, isDisabled } = useInput({
+    agentState: state.agentState,
+    onSubmit: sendInput,
+  })
+
+  return (
+    <App
+      state={state}
+      inputValue={value}
+      onInputChange={onChange}
+      onSubmit={handleSubmit}
+    />
+  )
+}
+
+// =============================================================================
+// CLI エントリポイント
+// =============================================================================
+
+/**
+ * wn-core の CLI パスを解決する。
+ *
+ * npm パッケージ @0x6d61/wn-core の dist/cli.js を探す。
+ * createRequire を使用して node_modules 内のパスを解決する。
+ */
+function resolveCoreCliPath(): string {
+  try {
+    // ESM 環境で require.resolve を使うために createRequire を利用
+    const require = createRequire(import.meta.url)
+    // wn-core のメインモジュールのパスを解決し、そこから cli.js を導出
+    const coreMainPath = require.resolve('@0x6d61/wn-core')
+    const coreDir = dirname(coreMainPath)
+    return join(coreDir, 'cli.js')
+  } catch {
+    // フォールバック: 直接パスを指定（開発時など）
+    throw new Error(
+      'Could not resolve @0x6d61/wn-core CLI path. ' +
+      'Make sure @0x6d61/wn-core is installed.',
+    )
+  }
+}
+
+function main(): void {
+  const corePath = resolveCoreCliPath()
+  const coreArgs = process.argv.slice(2)
+
+  render(<WnApp corePath={corePath} coreArgs={coreArgs} />)
+}
+
+main()

--- a/tests/hooks/use-core.test.tsx
+++ b/tests/hooks/use-core.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import { mapEventToAction } from '../../src/hooks/use-core.js'
+import type { CoreEvent } from '../../src/rpc/types.js'
+import type { AppAction } from '../../src/state/reducer.js'
+
+describe('mapEventToAction', () => {
+  it('response イベントを RESPONSE アクションにマッピングする', () => {
+    const event: CoreEvent = { type: 'response', content: 'Hello, world!' }
+    const action = mapEventToAction(event)
+
+    expect(action).toEqual({
+      type: 'RESPONSE',
+      content: 'Hello, world!',
+    } satisfies AppAction)
+  })
+
+  it('toolStart イベントを TOOL_START アクションにマッピングする', () => {
+    const event: CoreEvent = {
+      type: 'toolStart',
+      name: 'read',
+      args: { path: '/tmp/file.txt' },
+    }
+    const action = mapEventToAction(event)
+
+    expect(action).toEqual({
+      type: 'TOOL_START',
+      name: 'read',
+      args: { path: '/tmp/file.txt' },
+    } satisfies AppAction)
+  })
+
+  it('toolEnd イベントを TOOL_END アクションにマッピングする', () => {
+    const event: CoreEvent = {
+      type: 'toolEnd',
+      name: 'read',
+      result: { ok: true, output: 'file content' },
+    }
+    const action = mapEventToAction(event)
+
+    expect(action).toEqual({
+      type: 'TOOL_END',
+      name: 'read',
+      result: { ok: true, output: 'file content' },
+    } satisfies AppAction)
+  })
+
+  it('stateChange イベントを STATE_CHANGE アクションにマッピングする', () => {
+    const event: CoreEvent = { type: 'stateChange', state: 'thinking' }
+    const action = mapEventToAction(event)
+
+    expect(action).toEqual({
+      type: 'STATE_CHANGE',
+      state: 'thinking',
+    } satisfies AppAction)
+  })
+
+  it('log イベントを LOG アクションにマッピングする', () => {
+    const event: CoreEvent = {
+      type: 'log',
+      level: 'error',
+      message: 'Something went wrong',
+    }
+    const action = mapEventToAction(event)
+
+    expect(action).toEqual({
+      type: 'LOG',
+      level: 'error',
+      message: 'Something went wrong',
+    } satisfies AppAction)
+  })
+
+  it('log イベントの info レベルを正しくマッピングする', () => {
+    const event: CoreEvent = {
+      type: 'log',
+      level: 'info',
+      message: 'Info message',
+    }
+    const action = mapEventToAction(event)
+
+    expect(action).toEqual({
+      type: 'LOG',
+      level: 'info',
+      message: 'Info message',
+    } satisfies AppAction)
+  })
+
+  it('log イベントの warn レベルを正しくマッピングする', () => {
+    const event: CoreEvent = {
+      type: 'log',
+      level: 'warn',
+      message: 'Warning message',
+    }
+    const action = mapEventToAction(event)
+
+    expect(action).toEqual({
+      type: 'LOG',
+      level: 'warn',
+      message: 'Warning message',
+    } satisfies AppAction)
+  })
+
+  it('toolEnd イベントでエラー結果を正しくマッピングする', () => {
+    const event: CoreEvent = {
+      type: 'toolEnd',
+      name: 'shell',
+      result: { ok: false, output: '', error: 'command not found' },
+    }
+    const action = mapEventToAction(event)
+
+    expect(action).toEqual({
+      type: 'TOOL_END',
+      name: 'shell',
+      result: { ok: false, output: '', error: 'command not found' },
+    } satisfies AppAction)
+  })
+})

--- a/tests/hooks/use-input.test.tsx
+++ b/tests/hooks/use-input.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi } from 'vitest'
+import React from 'react'
+import { Text } from 'ink'
+import { render } from 'ink-testing-library'
+import { useInput } from '../../src/hooks/use-input.js'
+import type { AgentState } from '../../src/rpc/types.js'
+
+/**
+ * useInput フックをテストするためのラッパーコンポーネント。
+ * フックの結果をテキストとして描画し、ink-testing-library で検証する。
+ */
+function TestComponent({
+  agentState,
+  onSubmit,
+  initialValue,
+}: {
+  readonly agentState: AgentState
+  readonly onSubmit: (text: string) => Promise<void>
+  readonly initialValue?: string
+}): React.ReactElement {
+  const { value, onChange, handleSubmit, isDisabled } = useInput({
+    agentState,
+    onSubmit,
+  })
+
+  // initialValue を設定するための ref トリック（一度だけ呼ぶ）
+  const initialized = React.useRef(false)
+  if (!initialized.current && initialValue) {
+    onChange(initialValue)
+    initialized.current = true
+  }
+
+  return (
+    <Text>
+      {`disabled:${String(isDisabled)}|value:${value}|submit:${handleSubmit.name}`}
+    </Text>
+  )
+}
+
+/**
+ * handleSubmit を直接テストするためのコンポーネント。
+ * submit ボタンの代わりにマウント時に handleSubmit を呼ぶ。
+ */
+function SubmitTestComponent({
+  agentState,
+  onSubmit,
+  textToSubmit,
+}: {
+  readonly agentState: AgentState
+  readonly onSubmit: (text: string) => Promise<void>
+  readonly textToSubmit: string
+}): React.ReactElement {
+  const { value, onChange, handleSubmit, isDisabled } = useInput({
+    agentState,
+    onSubmit,
+  })
+
+  // 初回レンダーで値を設定し、次のレンダーで submit
+  const phase = React.useRef<'init' | 'set' | 'submit' | 'done'>('init')
+
+  React.useEffect(() => {
+    if (phase.current === 'init') {
+      phase.current = 'set'
+      onChange(textToSubmit)
+    }
+  }, [onChange, textToSubmit])
+
+  React.useEffect(() => {
+    if (phase.current === 'set' && value === textToSubmit) {
+      phase.current = 'submit'
+      handleSubmit(value)
+      phase.current = 'done'
+    }
+  }, [value, textToSubmit, handleSubmit])
+
+  return <Text>{`disabled:${String(isDisabled)}|value:${value}`}</Text>
+}
+
+/**
+ * 空文字列で handleSubmit を呼ぶテスト用コンポーネント
+ */
+function EmptySubmitTestComponent({
+  agentState,
+  onSubmit,
+}: {
+  readonly agentState: AgentState
+  readonly onSubmit: (text: string) => Promise<void>
+}): React.ReactElement {
+  const { value, handleSubmit, isDisabled } = useInput({
+    agentState,
+    onSubmit,
+  })
+
+  const called = React.useRef(false)
+  React.useEffect(() => {
+    if (!called.current) {
+      called.current = true
+      handleSubmit('')
+    }
+  }, [handleSubmit])
+
+  return <Text>{`disabled:${String(isDisabled)}|value:${value}`}</Text>
+}
+
+describe('useInput', () => {
+  it('agentState が idle のとき isDisabled は false', () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const { lastFrame } = render(
+      <TestComponent agentState="idle" onSubmit={onSubmit} />,
+    )
+    const frame = lastFrame() ?? ''
+    expect(frame).toContain('disabled:false')
+  })
+
+  it('agentState が thinking のとき isDisabled は true', () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const { lastFrame } = render(
+      <TestComponent agentState="thinking" onSubmit={onSubmit} />,
+    )
+    const frame = lastFrame() ?? ''
+    expect(frame).toContain('disabled:true')
+  })
+
+  it('agentState が tool_running のとき isDisabled は true', () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const { lastFrame } = render(
+      <TestComponent agentState="tool_running" onSubmit={onSubmit} />,
+    )
+    const frame = lastFrame() ?? ''
+    expect(frame).toContain('disabled:true')
+  })
+
+  it('agentState が waiting_input のとき isDisabled は false', () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const { lastFrame } = render(
+      <TestComponent agentState="waiting_input" onSubmit={onSubmit} />,
+    )
+    const frame = lastFrame() ?? ''
+    expect(frame).toContain('disabled:false')
+  })
+
+  it('handleSubmit は onSubmit を呼び出し、value をリセットする', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const { lastFrame } = render(
+      <SubmitTestComponent
+        agentState="idle"
+        onSubmit={onSubmit}
+        textToSubmit="hello"
+      />,
+    )
+
+    // React の effect が処理されるまで待つ
+    await vi.waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith('hello')
+    })
+
+    // submit 後に value がリセットされていること
+    await vi.waitFor(() => {
+      const frame = lastFrame() ?? ''
+      expect(frame).toContain('value:')
+      // value が空文字列にリセットされる
+      expect(frame).toMatch(/value:(?:$|\|)/)
+    })
+  })
+
+  it('handleSubmit は空文字列のとき onSubmit を呼ばない', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(
+      <EmptySubmitTestComponent agentState="idle" onSubmit={onSubmit} />,
+    )
+
+    // 少し待ってから onSubmit が呼ばれていないことを確認
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- `useCore` hook: Core プロセス接続管理、RPC イベント → State アクション変換
- `useInput` hook: 入力エリア制御（thinking/tool_running 中は無効化）
- `index.tsx`: CLI エントリポイント（`@0x6d61/wn-core` の CLI パスを自動解決）
- 14 新規テスト（全83テストパス）

## Test plan
- [x] `npm test` で全83テスト Green
- [x] `npx tsc --noEmit` で型チェックパス
- [ ] `npm run dev` で wn-tui を起動し、wn-core と通信できることを確認

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)