### PR TITLE
Fix tsup shebang duplication and Windows EFTYPE spawn error

### DIFF
--- a/src/rpc/client.ts
+++ b/src/rpc/client.ts
@@ -261,9 +261,14 @@ export function createCoreClient(options: CoreClientOptions): CoreClient {
   >()
   let nextId = 1
 
+  // .js ファイルの場合は node 経由で起動（Windows では .js を直接 spawn できない）
+  const isJsFile = sanitizedPath.endsWith('.js')
+  const command = isJsFile ? process.execPath : sanitizedPath
+  const args = isJsFile ? [sanitizedPath, ...coreArgs] : [...coreArgs]
+
   // 検証済みパスで子プロセスを起動（shell: false でシェル経由しない）
   // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
-  const child = spawn(sanitizedPath, [...coreArgs], {
+  const child = spawn(command, args, {
     stdio: ['pipe', 'pipe', 'pipe'],
     shell: false,
   })

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,7 +7,4 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   target: 'node20',
-  banner: {
-    js: '#!/usr/bin/env node',
-  },
 })


### PR DESCRIPTION
## Summary
- Remove duplicate shebang from tsup banner (already exists in `src/index.tsx`)
- Spawn `.js` files via `process.execPath` (node) instead of directly, fixing `EFTYPE` on Windows

## Test plan
- [x] All 83 tests pass (`npm test`)
- [x] `npm run build` succeeds with single shebang in `dist/index.js`
- [ ] `npx wn` no longer throws SyntaxError or EFTYPE

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)