### PR TITLE
Fix disconnect after setup wizard completion

### DIFF
--- a/src/hooks/use-core.ts
+++ b/src/hooks/use-core.ts
@@ -86,6 +86,10 @@ export function useCore(options: UseCoreOptions): UseCoreResult {
           error: `Process exited with code ${String(code)}`,
         })
       },
+      onStderr: (line: string) => {
+        // stderr 出力をエラーログとして dispatch
+        dispatch({ type: 'LOG', level: 'error', message: `[core] ${line}` })
+      },
     })
 
     clientRef.current = client

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -94,7 +94,10 @@ function resolveCoreCliPath(): string {
 
 function main(): void {
   const corePath = resolveCoreCliPath()
-  const coreArgs = process.argv.slice(2)
+  // wn-core は 'serve' サブコマンドで JSON-RPC サーバーとして起動する
+  // ユーザーの CLI 引数はその後に渡す
+  const userArgs = process.argv.slice(2)
+  const coreArgs = ['serve', ...userArgs]
 
   render(<Root corePath={corePath} coreArgs={coreArgs} />)
 }

--- a/src/rpc/client.ts
+++ b/src/rpc/client.ts
@@ -42,6 +42,7 @@ export interface CoreClientOptions {
   readonly coreArgs?: readonly string[]
   readonly onEvent: (event: CoreEvent) => void
   readonly onExit: (code: number | null) => void
+  readonly onStderr?: (line: string) => void
 }
 
 /** Core プロセスとの通信クライアント */
@@ -247,7 +248,7 @@ export function validateCorePath(rawPath: string): string {
  * @throws {Error} corePath が不正または実行不可能な場合
  */
 export function createCoreClient(options: CoreClientOptions): CoreClient {
-  const { corePath, coreArgs = [], onEvent, onExit } = options
+  const { corePath, coreArgs = [], onEvent, onExit, onStderr } = options
 
   // corePath を検証・サニタイズ（危険な文字の排除、絶対パスへの正規化、存在チェック）
   const sanitizedPath = validateCorePath(corePath)
@@ -315,6 +316,22 @@ export function createCoreClient(options: CoreClientOptions): CoreClient {
       // パースに失敗した通知は無視（クラッシュしない）
       return
     }
+  })
+
+  // stderr を行単位で読み取り、onStderr コールバックに渡す
+  if (onStderr) {
+    const stderrRl = createInterface({ input: child.stderr! })
+    stderrRl.on('line', (line: string) => {
+      onStderr(line)
+    })
+  }
+
+  // spawn 自体のエラー（ファイルが見つからない等）
+  // close イベントがエラー後に発火するので、ここでは追加の処理は不要
+  // ただし、ハンドラがないと unhandled error で crash するため登録する
+  child.on('error', () => {
+    // spawn error の場合は close イベントが code=null で発火する
+    // onExit は close ハンドラが呼ぶので、ここでは何もしない
   })
 
   // 子プロセスの終了イベント

--- a/tests/rpc/client.test.ts
+++ b/tests/rpc/client.test.ts
@@ -520,4 +520,88 @@ describe('createCoreClient', () => {
       unlinkSync(tmpFile)
     }
   })
+
+  it('存在しないコマンドを spawn した場合 onExit が呼ばれる', async () => {
+    const { createCoreClient } = await import('../../src/rpc/client.js')
+    const onEvent = vi.fn()
+    const onExit = vi.fn()
+
+    // validateCorePath をバイパスするため、node の -e で即座に exit するスクリプト
+    const client = createCoreClient({
+      corePath: process.execPath,
+      coreArgs: ['-e', 'process.exit(1)'],
+      onEvent,
+      onExit,
+    })
+
+    // プロセスが終了するまでポーリング
+    for (let i = 0; i < 20; i++) {
+      if (onExit.mock.calls.length > 0) break
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    }
+
+    expect(onExit).toHaveBeenCalledWith(1)
+    client.kill()
+  })
+
+  it('stderr 出力が onStderr コールバックに渡される', async () => {
+    const { createCoreClient } = await import('../../src/rpc/client.js')
+
+    const STDERR_SCRIPT = `
+      process.stderr.write('error message from core\\n');
+      setTimeout(() => {}, 500);
+    `
+
+    const onEvent = vi.fn()
+    const onExit = vi.fn()
+    const onStderr = vi.fn()
+
+    const client = createCoreClient({
+      corePath: process.execPath,
+      coreArgs: ['-e', STDERR_SCRIPT],
+      onEvent,
+      onExit,
+      onStderr,
+    })
+
+    // stderr が届くまで待つ
+    for (let i = 0; i < 20; i++) {
+      if (onStderr.mock.calls.length > 0) break
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    }
+
+    try {
+      expect(onStderr).toHaveBeenCalledWith('error message from core')
+    } finally {
+      client.kill()
+    }
+  })
+
+  it('onStderr が未指定でも stderr が出力されてクラッシュしない', async () => {
+    const { createCoreClient } = await import('../../src/rpc/client.js')
+
+    const STDERR_SCRIPT = `
+      process.stderr.write('some error\\n');
+      process.exit(0);
+    `
+
+    const onEvent = vi.fn()
+    const onExit = vi.fn()
+
+    // onStderr を指定しない
+    const client = createCoreClient({
+      corePath: process.execPath,
+      coreArgs: ['-e', STDERR_SCRIPT],
+      onEvent,
+      onExit,
+    })
+
+    for (let i = 0; i < 20; i++) {
+      if (onExit.mock.calls.length > 0) break
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    }
+
+    expect(onExit).toHaveBeenCalledWith(0)
+    client.kill()
+  })
 })


### PR DESCRIPTION
## Summary
- Fix wn-core spawned without `serve` subcommand, causing immediate exit (code 1)
- Add stderr capture to surface wn-core errors in TUI
- Add `child.on('error')` handler for spawn failure resilience

## Root cause
wn-core requires `serve` subcommand to start the JSON-RPC server. The TUI was passing only user CLI args without `serve`, so wn-core printed usage and exited immediately.

## Changes
- **`src/index.tsx`**: `coreArgs = ['serve', ...userArgs]`
- **`src/rpc/client.ts`**: `onStderr` callback + `child.on('error')` handler
- **`src/hooks/use-core.ts`**: Wire `onStderr` to dispatch `LOG(error)`
- **`tests/rpc/client.test.ts`**: 3 new tests for error handling

## Test plan
- [ ] `npm test` — all tests pass
- [ ] `npm run typecheck` — no errors
- [ ] `rm -rf ~/.wn && npm run dev` — wizard completes, app connects successfully
- [ ] Verify `● connected` in status bar after setup

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)