### PR TITLE
Rename package to weness and update wn-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "wn-tui",
+  "name": "weness",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "wn-tui",
+      "name": "weness",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@0x6d61/wn-core": "^0.1.3",
+        "@0x6d61/wn-core": "^0.1.5",
         "chalk": "^5.6.2",
         "ink": "^6.8.0",
         "ink-select-input": "^6.2.0",
@@ -71,9 +71,9 @@
       }
     },
     "node_modules/@0x6d61/wn-core": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@0x6d61/wn-core/-/wn-core-0.1.3.tgz",
-      "integrity": "sha512-5qawEu7iB7PtChDG38+qIT2Cl8iC56Ov1ew33ZUoVSUOhkonwOP/EKGePDsn7xc28O7ZgsDNfz2Kiz9H08QlaA==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@0x6d61/wn-core/-/wn-core-0.1.5.tgz",
+      "integrity": "sha512-XTMwgPNlsnVtRLf1eAvZfFHe8Jpex0kSVKGgzJj3fsuFcPTOxAPHhqvNidg49BxIdd5xkDUA+NTUlIAhatBAIA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wn-tui",
+  "name": "weness",
   "version": "0.1.0",
   "description": "Terminal UI for weness AI Agent Core",
   "type": "module",
@@ -28,7 +28,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@0x6d61/wn-core": "^0.1.3",
+    "@0x6d61/wn-core": "^0.1.5",
     "chalk": "^5.6.2",
     "ink": "^6.8.0",
     "ink-select-input": "^6.2.0",


### PR DESCRIPTION
## Summary
- パッケージ名を `wn-tui` → `weness` に変更
- `@0x6d61/wn-core` 依存を `^0.1.3` → `^0.1.5` に更新（maxToolRounds制限撤廃対応）

## Test plan
- [x] 全191テスト通過
- [x] `npm install` 正常完了

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)