### PR TITLE
Fix incorrect Claude model IDs and improve model selection

### DIFF
--- a/src/commands/handle-command.ts
+++ b/src/commands/handle-command.ts
@@ -1,11 +1,19 @@
 import type { AppAction } from '../state/reducer.js'
+import { DEFAULT_MODELS, PROVIDER_MODELS } from '../setup/types.js'
+import type { Provider } from '../setup/types.js'
 import { parseSlashCommand } from './parse-command.js'
+
+/** Provider 型ガード */
+function isProvider(value: string): value is Provider {
+  return value === 'claude' || value === 'openai' || value === 'ollama' || value === 'gemini'
+}
 
 /** handleCommand に渡す依存関数群 */
 export interface CommandHandlerDeps {
   readonly sendInput: (text: string) => Promise<void>
   readonly sendConfigUpdate: (params: { provider?: string; model?: string }) => Promise<void>
   readonly dispatch: (action: AppAction) => void
+  readonly currentProvider: string | null
 }
 
 /**
@@ -24,12 +32,48 @@ export async function handleCommand(
   }
 
   switch (command.type) {
-    case 'model':
+    case 'model': {
+      if (deps.currentProvider === null) {
+        deps.dispatch({
+          type: 'LOG',
+          level: 'error',
+          message: 'Cannot set model: provider is not selected',
+        })
+        return
+      }
+      if (!isProvider(deps.currentProvider)) {
+        deps.dispatch({
+          type: 'LOG',
+          level: 'error',
+          message: `Invalid provider: ${deps.currentProvider}`,
+        })
+        return
+      }
+      const validModels = PROVIDER_MODELS[deps.currentProvider].map((m) => m.value)
+      if (!validModels.includes(command.value)) {
+        const modelList = validModels.join(', ')
+        deps.dispatch({
+          type: 'LOG',
+          level: 'error',
+          message: `Invalid model: ${command.value}. Available models for ${deps.currentProvider}: ${modelList}`,
+        })
+        return
+      }
       await deps.sendConfigUpdate({ model: command.value })
       return
-    case 'provider':
-      await deps.sendConfigUpdate({ provider: command.value })
+    }
+    case 'provider': {
+      if (!isProvider(command.value)) {
+        deps.dispatch({
+          type: 'LOG',
+          level: 'error',
+          message: `Invalid provider: ${command.value}. Available providers: claude, openai, ollama, gemini`,
+        })
+        return
+      }
+      await deps.sendConfigUpdate({ provider: command.value, model: DEFAULT_MODELS[command.value] })
       return
+    }
     case 'model_select':
       deps.dispatch({ type: 'ENTER_MODEL_SELECT' })
       return

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,13 @@ import { App } from './components/App.js'
 import { SetupWizard } from './components/SetupWizard.js'
 import { checkConfigExists, readConfig } from './setup/check.js'
 import { handleCommand } from './commands/handle-command.js'
+import { DEFAULT_MODELS } from './setup/types.js'
+import type { Provider } from './setup/types.js'
+
+/** Provider 型ガード */
+function isProvider(value: string): value is Provider {
+  return value === 'claude' || value === 'openai' || value === 'ollama' || value === 'gemini'
+}
 
 // =============================================================================
 // WnApp コンポーネント
@@ -41,15 +48,20 @@ function WnApp({ corePath, coreArgs, provider, model }: WnAppProps): React.React
 
   const { value, onChange, handleSubmit, isDisabled } = useInput({
     agentState: state.agentState,
-    onSubmit: (text: string) => handleCommand(text, { sendInput, sendConfigUpdate, dispatch }),
+    onSubmit: (text: string) => handleCommand(text, { sendInput, sendConfigUpdate, dispatch, currentProvider: state.provider }),
   })
 
   useKeyboardShortcuts({
     onToggleToolOutput: () => dispatch({ type: 'TOGGLE_TOOL_OUTPUT' }),
   })
 
-  const handleProviderSelect = useCallback((provider: string) => {
-    void sendConfigUpdate({ provider })
+  const handleProviderSelect = useCallback(async (selectedProvider: string) => {
+    try {
+      const defaultModel = isProvider(selectedProvider) ? DEFAULT_MODELS[selectedProvider] : undefined
+      await sendConfigUpdate({ provider: selectedProvider, model: defaultModel })
+    } catch {
+      dispatch({ type: 'LOG', level: 'error', message: `Failed to update provider: ${selectedProvider}` })
+    }
     dispatch({ type: 'EXIT_PROVIDER_SELECT' })
   }, [sendConfigUpdate, dispatch])
 
@@ -57,8 +69,12 @@ function WnApp({ corePath, coreArgs, provider, model }: WnAppProps): React.React
     dispatch({ type: 'EXIT_PROVIDER_SELECT' })
   }, [dispatch])
 
-  const handleModelSelect = useCallback((model: string) => {
-    void sendConfigUpdate({ model })
+  const handleModelSelect = useCallback(async (selectedModel: string) => {
+    try {
+      await sendConfigUpdate({ model: selectedModel })
+    } catch {
+      dispatch({ type: 'LOG', level: 'error', message: `Failed to update model: ${selectedModel}` })
+    }
     dispatch({ type: 'EXIT_MODEL_SELECT' })
   }, [sendConfigUpdate, dispatch])
 

--- a/src/setup/types.ts
+++ b/src/setup/types.ts
@@ -16,7 +16,7 @@ export type AuthMethod = 'apiKey' | 'oauthToken'
 
 /** プロバイダーごとのデフォルトモデル */
 export const DEFAULT_MODELS: Readonly<Record<Provider, string>> = {
-  claude: 'claude-sonnet-4-6-20260217',
+  claude: 'claude-sonnet-4-20250514',
   openai: 'gpt-4.1',
   ollama: 'llama3.3',
   gemini: 'gemini-2.5-flash',
@@ -33,8 +33,9 @@ export const PROVIDER_LABELS: Readonly<Record<Provider, string>> = {
 /** プロバイダーごとのモデル一覧 */
 export const PROVIDER_MODELS: Readonly<Record<Provider, ReadonlyArray<{ label: string; value: string }>>> = {
   claude: [
-    { label: 'Claude Sonnet 4.6', value: 'claude-sonnet-4-6-20260217' },
-    { label: 'Claude Opus 4.6', value: 'claude-opus-4-6-20260205' },
+    { label: 'Claude Sonnet 4', value: 'claude-sonnet-4-20250514' },
+    { label: 'Claude Sonnet 4.6', value: 'claude-sonnet-4-6' },
+    { label: 'Claude Opus 4.6', value: 'claude-opus-4-6' },
     { label: 'Claude Haiku 4.5', value: 'claude-haiku-4-5-20251001' },
   ],
   openai: [

--- a/tests/commands/handle-command.test.ts
+++ b/tests/commands/handle-command.test.ts
@@ -7,7 +7,7 @@ describe('handleCommand', () => {
     const sendConfigUpdate = vi.fn()
     const dispatch = vi.fn()
 
-    await handleCommand('hello world', { sendInput, sendConfigUpdate, dispatch })
+    await handleCommand('hello world', { sendInput, sendConfigUpdate, dispatch, currentProvider: 'claude' })
 
     expect(sendInput).toHaveBeenCalledWith('hello world')
     expect(sendConfigUpdate).not.toHaveBeenCalled()
@@ -18,20 +18,20 @@ describe('handleCommand', () => {
     const sendConfigUpdate = vi.fn()
     const dispatch = vi.fn()
 
-    await handleCommand('/model gpt-4o', { sendInput, sendConfigUpdate, dispatch })
+    await handleCommand('/model claude-sonnet-4-20250514', { sendInput, sendConfigUpdate, dispatch, currentProvider: 'claude' })
 
-    expect(sendConfigUpdate).toHaveBeenCalledWith({ model: 'gpt-4o' })
+    expect(sendConfigUpdate).toHaveBeenCalledWith({ model: 'claude-sonnet-4-20250514' })
     expect(sendInput).not.toHaveBeenCalled()
   })
 
-  it('/provider コマンドは sendConfigUpdate を呼ぶ', async () => {
+  it('/provider コマンドはデフォルトモデルも送信する', async () => {
     const sendInput = vi.fn()
     const sendConfigUpdate = vi.fn()
     const dispatch = vi.fn()
 
-    await handleCommand('/provider openai', { sendInput, sendConfigUpdate, dispatch })
+    await handleCommand('/provider openai', { sendInput, sendConfigUpdate, dispatch, currentProvider: 'claude' })
 
-    expect(sendConfigUpdate).toHaveBeenCalledWith({ provider: 'openai' })
+    expect(sendConfigUpdate).toHaveBeenCalledWith({ provider: 'openai', model: 'gpt-4.1' })
     expect(sendInput).not.toHaveBeenCalled()
   })
 
@@ -40,7 +40,7 @@ describe('handleCommand', () => {
     const sendConfigUpdate = vi.fn()
     const dispatch = vi.fn()
 
-    await handleCommand('/unknown foo', { sendInput, sendConfigUpdate, dispatch })
+    await handleCommand('/unknown foo', { sendInput, sendConfigUpdate, dispatch, currentProvider: 'claude' })
 
     expect(dispatch).toHaveBeenCalledWith({
       type: 'LOG',
@@ -56,7 +56,7 @@ describe('handleCommand', () => {
     const sendConfigUpdate = vi.fn()
     const dispatch = vi.fn()
 
-    await handleCommand('/provider', { sendInput, sendConfigUpdate, dispatch })
+    await handleCommand('/provider', { sendInput, sendConfigUpdate, dispatch, currentProvider: 'claude' })
 
     expect(dispatch).toHaveBeenCalledWith({ type: 'ENTER_PROVIDER_SELECT' })
     expect(sendInput).not.toHaveBeenCalled()
@@ -68,10 +68,55 @@ describe('handleCommand', () => {
     const sendConfigUpdate = vi.fn()
     const dispatch = vi.fn()
 
-    await handleCommand('/model', { sendInput, sendConfigUpdate, dispatch })
+    await handleCommand('/model', { sendInput, sendConfigUpdate, dispatch, currentProvider: 'claude' })
 
     expect(dispatch).toHaveBeenCalledWith({ type: 'ENTER_MODEL_SELECT' })
     expect(sendInput).not.toHaveBeenCalled()
+    expect(sendConfigUpdate).not.toHaveBeenCalled()
+  })
+
+  it('/provider で無効なプロバイダー名はエラーを返す', async () => {
+    const sendInput = vi.fn()
+    const sendConfigUpdate = vi.fn()
+    const dispatch = vi.fn()
+
+    await handleCommand('/provider invalid', { sendInput, sendConfigUpdate, dispatch, currentProvider: 'claude' })
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'LOG',
+      level: 'error',
+      message: expect.stringContaining('Invalid provider'),
+    })
+    expect(sendConfigUpdate).not.toHaveBeenCalled()
+  })
+
+  it('/model で無効なモデル名はエラーを返す', async () => {
+    const sendInput = vi.fn()
+    const sendConfigUpdate = vi.fn()
+    const dispatch = vi.fn()
+
+    await handleCommand('/model foobar', { sendInput, sendConfigUpdate, dispatch, currentProvider: 'claude' })
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'LOG',
+      level: 'error',
+      message: expect.stringContaining('Invalid model'),
+    })
+    expect(sendConfigUpdate).not.toHaveBeenCalled()
+  })
+
+  it('/model で currentProvider が null の場合エラーを返す', async () => {
+    const sendInput = vi.fn()
+    const sendConfigUpdate = vi.fn()
+    const dispatch = vi.fn()
+
+    await handleCommand('/model gpt-4.1', { sendInput, sendConfigUpdate, dispatch, currentProvider: null })
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'LOG',
+      level: 'error',
+      message: expect.stringContaining('provider'),
+    })
     expect(sendConfigUpdate).not.toHaveBeenCalled()
   })
 })

--- a/tests/components/app.test.tsx
+++ b/tests/components/app.test.tsx
@@ -143,7 +143,7 @@ describe('App', () => {
       connected: true,
       agentState: 'idle',
       provider: 'claude',
-      model: 'claude-sonnet-4-6-20260217',
+      model: 'claude-sonnet-4-20250514',
       selectMode: 'model',
     }
     const { lastFrame } = render(

--- a/tests/components/model-selector.test.tsx
+++ b/tests/components/model-selector.test.tsx
@@ -12,6 +12,7 @@ describe('ModelSelector', () => {
     )
     const frame = lastFrame() ?? ''
     expect(frame).toContain('Select model:')
+    expect(frame).toContain('Claude Sonnet 4')
     expect(frame).toContain('Claude Sonnet 4.6')
     expect(frame).toContain('Claude Opus 4.6')
     expect(frame).toContain('Claude Haiku 4.5')
@@ -34,9 +35,9 @@ describe('ModelSelector', () => {
     const { stdin } = render(
       <ModelSelector provider="claude" onSelect={onSelect} onCancel={onCancel} />,
     )
-    // Enter で最初の項目（Claude Sonnet 4.6）を選択
+    // Enter で最初の項目（Claude Sonnet 4）を選択
     stdin.write('\r')
-    expect(onSelect).toHaveBeenCalledWith('claude-sonnet-4-6-20260217')
+    expect(onSelect).toHaveBeenCalledWith('claude-sonnet-4-20250514')
   })
 
   it('provider が null のときエラーメッセージを表示する', () => {

--- a/tests/setup/create.test.ts
+++ b/tests/setup/create.test.ts
@@ -58,7 +58,7 @@ describe('createInitialConfig', () => {
 
       const config: WnConfig = JSON.parse(readFileSync(configPath, 'utf-8'))
       expect(config.defaultProvider).toBe('claude')
-      expect(config.defaultModel).toBe('claude-sonnet-4-6-20260217')
+      expect(config.defaultModel).toBe('claude-sonnet-4-20250514')
       expect(config.defaultPersona).toBe('default')
       expect(config.providers).toEqual({
         claude: { apiKey: 'sk-claude-key' },
@@ -92,7 +92,7 @@ describe('createInitialConfig', () => {
   // ===========================================================================
 
   describe('各プロバイダー別テスト', () => {
-    it('Claude (API Key): apiKey が設定される、モデルが claude-sonnet-4-6-20260217', () => {
+    it('Claude (API Key): apiKey が設定される、モデルが claude-sonnet-4-20250514', () => {
       const input: SetupResult = { provider: 'claude', authMethod: 'apiKey', credential: 'sk-ant-key123' }
       createInitialConfig(input, testDir)
 
@@ -100,7 +100,7 @@ describe('createInitialConfig', () => {
         readFileSync(join(testDir, '.wn', 'config.json'), 'utf-8'),
       )
       expect(config.defaultProvider).toBe('claude')
-      expect(config.defaultModel).toBe('claude-sonnet-4-6-20260217')
+      expect(config.defaultModel).toBe('claude-sonnet-4-20250514')
       expect(config.providers.claude?.apiKey).toBe('sk-ant-key123')
       expect(config.providers.claude?.authToken).toBeUndefined()
     })
@@ -113,7 +113,7 @@ describe('createInitialConfig', () => {
         readFileSync(join(testDir, '.wn', 'config.json'), 'utf-8'),
       )
       expect(config.defaultProvider).toBe('claude')
-      expect(config.defaultModel).toBe('claude-sonnet-4-6-20260217')
+      expect(config.defaultModel).toBe('claude-sonnet-4-20250514')
       expect(config.providers.claude?.authToken).toBe('oauth-token-abc')
     })
 

--- a/tests/setup/types.test.ts
+++ b/tests/setup/types.test.ts
@@ -3,8 +3,8 @@ import { DEFAULT_MODELS, PROVIDER_MODELS } from '../../src/setup/types.js'
 import type { Provider } from '../../src/setup/types.js'
 
 describe('DEFAULT_MODELS', () => {
-  it('claude のデフォルトモデルは claude-sonnet-4-6-20260217 である', () => {
-    expect(DEFAULT_MODELS.claude).toBe('claude-sonnet-4-6-20260217')
+  it('claude のデフォルトモデルは claude-sonnet-4-20250514 である', () => {
+    expect(DEFAULT_MODELS.claude).toBe('claude-sonnet-4-20250514')
   })
 
   it('openai のデフォルトモデルは gpt-4.1 である', () => {
@@ -43,14 +43,19 @@ describe('PROVIDER_MODELS', () => {
     }
   })
 
+  it('claude のモデル一覧に Claude Sonnet 4 が含まれる', () => {
+    const values = PROVIDER_MODELS.claude.map((m) => m.value)
+    expect(values).toContain('claude-sonnet-4-20250514')
+  })
+
   it('claude のモデル一覧に Claude Sonnet 4.6 が含まれる', () => {
     const values = PROVIDER_MODELS.claude.map((m) => m.value)
-    expect(values).toContain('claude-sonnet-4-6-20260217')
+    expect(values).toContain('claude-sonnet-4-6')
   })
 
   it('claude のモデル一覧に Claude Opus 4.6 が含まれる', () => {
     const values = PROVIDER_MODELS.claude.map((m) => m.value)
-    expect(values).toContain('claude-opus-4-6-20260205')
+    expect(values).toContain('claude-opus-4-6')
   })
 
   it('claude のモデル一覧に Claude Haiku 4.5 が含まれる', () => {


### PR DESCRIPTION
## Summary
- Fix fabricated Claude model IDs causing 404 errors on Anthropic API (`claude-sonnet-4-6-20260217` → `claude-sonnet-4-20250514`, etc.)
- Add auto-reset of model to provider default when changing provider via `/provider` command or UI selector
- Add input validation for `/model` and `/provider` slash commands (reject invalid values with error message)
- Add try-catch error handling for RPC calls in `handleProviderSelect` / `handleModelSelect`

## Changes

### Model ID fix (`src/setup/types.ts`)
| Before (incorrect) | After (correct) |
|---------------------|-----------------|
| `claude-sonnet-4-6-20260217` | `claude-sonnet-4-20250514` |
| `claude-opus-4-6-20260205` | `claude-opus-4-6` |

Added `claude-sonnet-4-6` (Claude Sonnet 4.6) to model list.

### Provider change model reset (`src/commands/handle-command.ts`, `src/index.tsx`)
- `/provider openai` now sends `{ provider: 'openai', model: 'gpt-4.1' }` instead of just `{ provider: 'openai' }`

### Validation (`src/commands/handle-command.ts`)
- `/provider invalid` → error with available providers list
- `/model foobar` → error with available models for current provider

## Test plan
- [x] `tests/setup/types.test.ts` — model ID assertions updated (15 tests)
- [x] `tests/commands/handle-command.test.ts` — 4 new tests for validation & provider reset (9 tests total)
- [x] `tests/components/model-selector.test.tsx` — label & value assertions updated (4 tests)
- [x] `tests/components/app.test.tsx` — model ID updated (7 tests)
- [x] `tests/setup/create.test.ts` — model ID updated (12 tests)
- [x] All 195 tests pass (`npm test`)

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)