### PR TITLE
Add multi-line paste compact display like Claude Code

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -11,15 +11,18 @@ import { ModelSelector } from './ModelSelector.js'
 interface AppProps {
   readonly state: AppState
   readonly inputValue: string
+  readonly displayValue: string
+  readonly isMultiLine: boolean
   readonly onInputChange: (value: string) => void
   readonly onSubmit: (text: string) => void
+  readonly onClearMultiLine: () => void
   readonly onProviderSelect?: (provider: string) => void
   readonly onProviderSelectCancel?: () => void
   readonly onModelSelect?: (model: string) => void
   readonly onModelSelectCancel?: () => void
 }
 
-export function App({ state, inputValue, onInputChange, onSubmit, onProviderSelect, onProviderSelectCancel, onModelSelect, onModelSelectCancel }: AppProps): React.ReactElement {
+export function App({ state, inputValue, displayValue, isMultiLine, onInputChange, onSubmit, onClearMultiLine, onProviderSelect, onProviderSelectCancel, onModelSelect, onModelSelectCancel }: AppProps): React.ReactElement {
   const isDisabled = state.agentState === 'tool_running'
   const isActive = state.agentState === 'thinking' || state.agentState === 'tool_running'
 
@@ -51,8 +54,11 @@ export function App({ state, inputValue, onInputChange, onSubmit, onProviderSele
             />
           : <InputArea
               value={inputValue}
+              displayValue={displayValue}
+              isMultiLine={isMultiLine}
               onChange={onInputChange}
               onSubmit={onSubmit}
+              onClearMultiLine={onClearMultiLine}
               isDisabled={isDisabled}
             />
       }

--- a/src/components/InputArea.tsx
+++ b/src/components/InputArea.tsx
@@ -1,20 +1,68 @@
 import React from 'react'
-import { Box, Text } from 'ink'
+import { Box, Text, useInput as useInkInput } from 'ink'
 import TextInput from 'ink-text-input'
 
 interface InputAreaProps {
   readonly value: string
+  readonly displayValue: string
+  readonly isMultiLine: boolean
   readonly onChange: (value: string) => void
   readonly onSubmit: (value: string) => void
+  readonly onClearMultiLine: () => void
   readonly isDisabled: boolean
 }
 
-export function InputArea({ value, onChange, onSubmit, isDisabled }: InputAreaProps): React.ReactElement {
+/**
+ * 複数行ペースト時のキー入力ハンドラコンポーネント。
+ * useInput（ink のフック）は条件付き呼び出しができないため、
+ * 常にマウントされる別コンポーネントとして分離する。
+ */
+function MultiLineKeyHandler({
+  value,
+  onSubmit,
+  onClearMultiLine,
+  isActive,
+}: {
+  readonly value: string
+  readonly onSubmit: (value: string) => void
+  readonly onClearMultiLine: () => void
+  readonly isActive: boolean
+}): React.ReactElement | null {
+  useInkInput(
+    (input, key) => {
+      if (key.return) {
+        onSubmit(value)
+      } else if (key.escape) {
+        onClearMultiLine()
+      }
+    },
+    { isActive },
+  )
+  return null
+}
+
+export function InputArea({ value, displayValue, isMultiLine, onChange, onSubmit, onClearMultiLine, isDisabled }: InputAreaProps): React.ReactElement {
   if (isDisabled) {
     return (
       <Box borderStyle="round" borderDimColor paddingLeft={1} paddingRight={1}>
         <Text dimColor>{'❯ '}</Text>
         <Text dimColor>{value}</Text>
+      </Box>
+    )
+  }
+
+  if (isMultiLine) {
+    return (
+      <Box borderStyle="round" borderDimColor paddingLeft={1} paddingRight={1}>
+        <Text>{'❯ '}</Text>
+        <Text>{displayValue}</Text>
+        <Text dimColor>{' (Enter: send, Esc: clear)'}</Text>
+        <MultiLineKeyHandler
+          value={value}
+          onSubmit={onSubmit}
+          onClearMultiLine={onClearMultiLine}
+          isActive={true}
+        />
       </Box>
     )
   }

--- a/src/hooks/use-input.ts
+++ b/src/hooks/use-input.ts
@@ -5,7 +5,7 @@
  * 無効化制御を提供する。
  */
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import type { AgentState } from '../rpc/types.js'
 
 // =============================================================================
@@ -19,8 +19,12 @@ interface UseInputOptions {
 
 interface UseInputResult {
   readonly value: string
+  readonly displayValue: string
+  readonly isMultiLine: boolean
+  readonly lineCount: number
   readonly onChange: (value: string) => void
   readonly handleSubmit: (value: string) => void
+  readonly clearMultiLine: () => void
   readonly isDisabled: boolean
 }
 
@@ -38,23 +42,52 @@ interface UseInputResult {
 export function useInput(options: UseInputOptions): UseInputResult {
   const { agentState, onSubmit } = options
   const [value, setValue] = useState('')
+  const [isMultiLine, setIsMultiLine] = useState(false)
+  const [lineCount, setLineCount] = useState(1)
 
   const isDisabled = agentState === 'tool_running'
 
   const onChange = useCallback((newValue: string): void => {
     setValue(newValue)
+    const lines = newValue.split('\n')
+    if (lines.length >= 3) {
+      setIsMultiLine(true)
+      setLineCount(lines.length)
+    } else {
+      setIsMultiLine(false)
+      setLineCount(lines.length)
+    }
+  }, [])
+
+  const displayValue = useMemo((): string => {
+    if (!isMultiLine) return value
+    const lines = value.split('\n')
+    const firstLine = lines[0] ?? ''
+    const extraLines = lines.length - 1
+    const truncated = firstLine.length > 50 ? firstLine.slice(0, 50) + '...' : firstLine
+    return `${truncated} [+${extraLines} lines]`
+  }, [value, isMultiLine])
+
+  const clearMultiLine = useCallback((): void => {
+    setValue('')
+    setIsMultiLine(false)
+    setLineCount(1)
   }, [])
 
   const handleSubmit = useCallback(
     (text: string): void => {
-      if (isDisabled || text.length === 0) {
+      // isMultiLine の場合は value を使って送信（text は displayValue かもしれない）
+      const submitText = isMultiLine ? value : text
+      if (isDisabled || submitText.length === 0) {
         return
       }
-      void onSubmit(text)
+      void onSubmit(submitText)
       setValue('')
+      setIsMultiLine(false)
+      setLineCount(1)
     },
-    [isDisabled, onSubmit],
+    [isDisabled, onSubmit, isMultiLine, value],
   )
 
-  return { value, onChange, handleSubmit, isDisabled }
+  return { value, displayValue, isMultiLine, lineCount, onChange, handleSubmit, clearMultiLine, isDisabled }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,7 +39,7 @@ function WnApp({ corePath, coreArgs, provider, model }: WnAppProps): React.React
     dispatch({ type: 'SET_CONFIG', provider, model })
   }, [dispatch, provider, model])
 
-  const { value, onChange, handleSubmit, isDisabled } = useInput({
+  const { value, displayValue, isMultiLine, onChange, handleSubmit, clearMultiLine, isDisabled } = useInput({
     agentState: state.agentState,
     onSubmit: (text: string) => handleCommand(text, { sendInput, sendConfigUpdate, dispatch }),
   })
@@ -70,8 +70,11 @@ function WnApp({ corePath, coreArgs, provider, model }: WnAppProps): React.React
     <App
       state={state}
       inputValue={value}
+      displayValue={displayValue}
+      isMultiLine={isMultiLine}
       onInputChange={onChange}
       onSubmit={handleSubmit}
+      onClearMultiLine={clearMultiLine}
       onProviderSelect={handleProviderSelect}
       onProviderSelectCancel={handleProviderSelectCancel}
       onModelSelect={handleModelSelect}

--- a/tests/components/app.test.tsx
+++ b/tests/components/app.test.tsx
@@ -34,6 +34,9 @@ describe('App', () => {
         inputValue=""
         onInputChange={() => {}}
         onSubmit={() => {}}
+        displayValue=""
+        isMultiLine={false}
+        onClearMultiLine={() => {}}
       />,
     )
     const frame = lastFrame() ?? ''
@@ -60,6 +63,9 @@ describe('App', () => {
         inputValue=""
         onInputChange={() => {}}
         onSubmit={() => {}}
+        displayValue=""
+        isMultiLine={false}
+        onClearMultiLine={() => {}}
       />,
     )
     const frame = lastFrame() ?? ''
@@ -84,6 +90,9 @@ describe('App', () => {
         inputValue=""
         onInputChange={() => {}}
         onSubmit={() => {}}
+        displayValue=""
+        isMultiLine={false}
+        onClearMultiLine={() => {}}
       />,
     )
     const frame = lastFrame() ?? ''
@@ -105,6 +114,9 @@ describe('App', () => {
         inputValue=""
         onInputChange={() => {}}
         onSubmit={() => {}}
+        displayValue=""
+        isMultiLine={false}
+        onClearMultiLine={() => {}}
       />,
     )
     const frame = lastFrame() ?? ''
@@ -126,6 +138,9 @@ describe('App', () => {
         inputValue=""
         onInputChange={() => {}}
         onSubmit={() => {}}
+        displayValue=""
+        isMultiLine={false}
+        onClearMultiLine={() => {}}
       />,
     )
     const frame = lastFrame() ?? ''
@@ -152,6 +167,9 @@ describe('App', () => {
         inputValue=""
         onInputChange={() => {}}
         onSubmit={() => {}}
+        displayValue=""
+        isMultiLine={false}
+        onClearMultiLine={() => {}}
       />,
     )
     const frame = lastFrame() ?? ''
@@ -176,6 +194,9 @@ describe('App', () => {
         inputValue=""
         onInputChange={() => {}}
         onSubmit={() => {}}
+        displayValue=""
+        isMultiLine={false}
+        onClearMultiLine={() => {}}
       />,
     )
     const frame = lastFrame() ?? ''

--- a/tests/components/input-area.test.tsx
+++ b/tests/components/input-area.test.tsx
@@ -8,8 +8,11 @@ describe('InputArea', () => {
     const { lastFrame } = render(
       <InputArea
         value=""
+        displayValue=""
+        isMultiLine={false}
         onChange={() => {}}
         onSubmit={() => {}}
+        onClearMultiLine={() => {}}
         isDisabled={false}
       />,
     )
@@ -21,8 +24,11 @@ describe('InputArea', () => {
     const { lastFrame } = render(
       <InputArea
         value="processing..."
+        displayValue="processing..."
+        isMultiLine={false}
         onChange={() => {}}
         onSubmit={() => {}}
+        onClearMultiLine={() => {}}
         isDisabled={true}
       />,
     )
@@ -34,8 +40,11 @@ describe('InputArea', () => {
     const { lastFrame } = render(
       <InputArea
         value="hello"
+        displayValue="hello"
+        isMultiLine={false}
         onChange={() => {}}
         onSubmit={() => {}}
+        onClearMultiLine={() => {}}
         isDisabled={false}
       />,
     )
@@ -47,12 +56,70 @@ describe('InputArea', () => {
     const { lastFrame } = render(
       <InputArea
         value=""
+        displayValue=""
+        isMultiLine={false}
         onChange={() => {}}
         onSubmit={() => {}}
+        onClearMultiLine={() => {}}
         isDisabled={false}
       />,
     )
     const frame = lastFrame() ?? ''
     expect(frame).toContain('│')
+  })
+
+  // =============================================================================
+  // 複数行ペースト機能のテスト
+  // =============================================================================
+
+  it('isMultiLine=true のとき displayValue を表示する', () => {
+    const { lastFrame } = render(
+      <InputArea
+        value="line1\nline2\nline3"
+        displayValue="line1 [+2 lines]"
+        isMultiLine={true}
+        onChange={() => {}}
+        onSubmit={() => {}}
+        onClearMultiLine={() => {}}
+        isDisabled={false}
+      />,
+    )
+    const frame = lastFrame() ?? ''
+    expect(frame).toContain('line1 [+2 lines]')
+  })
+
+  it('isMultiLine=true のときヒントテキストを表示する', () => {
+    const { lastFrame } = render(
+      <InputArea
+        value="line1\nline2\nline3"
+        displayValue="line1 [+2 lines]"
+        isMultiLine={true}
+        onChange={() => {}}
+        onSubmit={() => {}}
+        onClearMultiLine={() => {}}
+        isDisabled={false}
+      />,
+    )
+    const frame = lastFrame() ?? ''
+    expect(frame).toContain('Enter: send')
+    expect(frame).toContain('Esc: clear')
+  })
+
+  it('isMultiLine=false のとき通常の TextInput を表示する', () => {
+    const { lastFrame } = render(
+      <InputArea
+        value="normal text"
+        displayValue="normal text"
+        isMultiLine={false}
+        onChange={() => {}}
+        onSubmit={() => {}}
+        onClearMultiLine={() => {}}
+        isDisabled={false}
+      />,
+    )
+    const frame = lastFrame() ?? ''
+    // 通常モードでは TextInput が描画される（ヒントテキストは表示されない）
+    expect(frame).not.toContain('Enter: send')
+    expect(frame).toContain('❯')
   })
 })

--- a/tests/hooks/use-input.test.tsx
+++ b/tests/hooks/use-input.test.tsx
@@ -18,21 +18,23 @@ function TestComponent({
   readonly onSubmit: (text: string) => Promise<void>
   readonly initialValue?: string
 }): React.ReactElement {
-  const { value, onChange, handleSubmit, isDisabled } = useInput({
+  const { value, displayValue, isMultiLine, lineCount, onChange, handleSubmit, isDisabled } = useInput({
     agentState,
     onSubmit,
   })
 
-  // initialValue を設定するための ref トリック（一度だけ呼ぶ）
+  // initialValue を useEffect で設定（レンダリング中の setState を避ける）
   const initialized = React.useRef(false)
-  if (!initialized.current && initialValue) {
-    onChange(initialValue)
-    initialized.current = true
-  }
+  React.useEffect(() => {
+    if (!initialized.current && initialValue) {
+      onChange(initialValue)
+      initialized.current = true
+    }
+  }, [onChange, initialValue])
 
   return (
     <Text>
-      {`disabled:${String(isDisabled)}|value:${value}|submit:${handleSubmit.name}`}
+      {`disabled:${String(isDisabled)}|value:${value}|multiline:${String(isMultiLine)}|lines:${lineCount}|display:${displayValue}|submit:${handleSubmit.name}`}
     </Text>
   )
 }
@@ -50,7 +52,7 @@ function SubmitTestComponent({
   readonly onSubmit: (text: string) => Promise<void>
   readonly textToSubmit: string
 }): React.ReactElement {
-  const { value, onChange, handleSubmit, isDisabled } = useInput({
+  const { value, isMultiLine, onChange, handleSubmit, isDisabled } = useInput({
     agentState,
     onSubmit,
   })
@@ -73,7 +75,49 @@ function SubmitTestComponent({
     }
   }, [value, textToSubmit, handleSubmit])
 
-  return <Text>{`disabled:${String(isDisabled)}|value:${value}`}</Text>
+  return <Text>{`disabled:${String(isDisabled)}|value:${value}|multiline:${String(isMultiLine)}`}</Text>
+}
+
+/**
+ * clearMultiLine テスト用コンポーネント
+ */
+function ClearMultiLineTestComponent({
+  agentState,
+  onSubmit,
+  initialValue,
+  shouldClear,
+}: {
+  readonly agentState: AgentState
+  readonly onSubmit: (text: string) => Promise<void>
+  readonly initialValue: string
+  readonly shouldClear: boolean
+}): React.ReactElement {
+  const { value, isMultiLine, lineCount, onChange, clearMultiLine, isDisabled } = useInput({
+    agentState,
+    onSubmit,
+  })
+
+  const initialized = React.useRef(false)
+  React.useEffect(() => {
+    if (!initialized.current) {
+      onChange(initialValue)
+      initialized.current = true
+    }
+  }, [onChange, initialValue])
+
+  const cleared = React.useRef(false)
+  React.useEffect(() => {
+    if (shouldClear && !cleared.current && isMultiLine) {
+      cleared.current = true
+      clearMultiLine()
+    }
+  }, [shouldClear, clearMultiLine, isMultiLine])
+
+  return (
+    <Text>
+      {`disabled:${String(isDisabled)}|value:${value}|multiline:${String(isMultiLine)}|lines:${lineCount}`}
+    </Text>
+  )
 }
 
 /**
@@ -172,5 +216,118 @@ describe('useInput', () => {
     // 少し待ってから onSubmit が呼ばれていないことを確認
     await new Promise((resolve) => setTimeout(resolve, 50))
     expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  // =============================================================================
+  // 複数行ペースト機能のテスト
+  // =============================================================================
+
+  it('通常入力で isMultiLine は false', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const { lastFrame } = render(
+      <TestComponent agentState="idle" onSubmit={onSubmit} initialValue="hello world" />,
+    )
+    await vi.waitFor(() => {
+      const frame = lastFrame() ?? ''
+      expect(frame).toContain('value:hello world')
+      expect(frame).toContain('multiline:false')
+      expect(frame).toContain('lines:1')
+    })
+  })
+
+  it('2行の入力で isMultiLine は false', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const { lastFrame } = render(
+      <TestComponent agentState="idle" onSubmit={onSubmit} initialValue={"line1\nline2"} />,
+    )
+    await vi.waitFor(() => {
+      const frame = lastFrame() ?? ''
+      expect(frame).toContain('multiline:false')
+      expect(frame).toContain('lines:2')
+    })
+  })
+
+  it('3行以上の入力で isMultiLine は true', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const { lastFrame } = render(
+      <TestComponent agentState="idle" onSubmit={onSubmit} initialValue={"line1\nline2\nline3"} />,
+    )
+    await vi.waitFor(() => {
+      const frame = lastFrame() ?? ''
+      expect(frame).toContain('multiline:true')
+      expect(frame).toContain('lines:3')
+    })
+  })
+
+  it('複数行の displayValue に [+N lines] が含まれる', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const { lastFrame } = render(
+      <TestComponent agentState="idle" onSubmit={onSubmit} initialValue={"first line\nsecond\nthird"} />,
+    )
+    await vi.waitFor(() => {
+      const frame = lastFrame() ?? ''
+      expect(frame).toContain('display:first line [+2 lines]')
+    })
+  })
+
+  it('50文字を超える最初の行は切り詰められる', async () => {
+    const longLine = 'a'.repeat(60)
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const { lastFrame } = render(
+      <TestComponent agentState="idle" onSubmit={onSubmit} initialValue={`${longLine}\nline2\nline3`} />,
+    )
+    await vi.waitFor(() => {
+      const frame = lastFrame() ?? ''
+      const truncated = 'a'.repeat(50) + '...'
+      // ink がターミナル幅でテキストを折り返すため、個別にチェックする
+      expect(frame).toContain('multiline:true')
+      expect(frame).toContain('lines:3')
+      // displayValue に切り詰められた文字列が含まれる
+      expect(frame).toContain(`display:${truncated}`)
+      // [+2 lines] が含まれる（ink の折り返しにより改行が入る場合がある）
+      expect(frame.replace(/\s+/g, '')).toContain('[+2lines]')
+    })
+  })
+
+  it('clearMultiLine で通常入力に戻る', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const { lastFrame } = render(
+      <ClearMultiLineTestComponent
+        agentState="idle"
+        onSubmit={onSubmit}
+        initialValue="line1\nline2\nline3"
+        shouldClear={true}
+      />,
+    )
+
+    await vi.waitFor(() => {
+      const frame = lastFrame() ?? ''
+      expect(frame).toContain('multiline:false')
+      expect(frame).toContain('value:')
+      expect(frame).toMatch(/value:(?:$|\|)/)
+      expect(frame).toContain('lines:1')
+    })
+  })
+
+  it('handleSubmit は複数行のとき全文を送信する', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const multiLineText = 'line1\nline2\nline3'
+    const { lastFrame } = render(
+      <SubmitTestComponent
+        agentState="idle"
+        onSubmit={onSubmit}
+        textToSubmit={multiLineText}
+      />,
+    )
+
+    await vi.waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(multiLineText)
+    })
+
+    // submit 後に multiline 状態もリセットされること
+    await vi.waitFor(() => {
+      const frame = lastFrame() ?? ''
+      expect(frame).toContain('multiline:false')
+    })
   })
 })


### PR DESCRIPTION
## Summary
- When 3+ lines are pasted into the input area, display a compact view: `first line... [+N lines]`
- Enter submits the full pasted text, Escape clears the input
- First line is truncated at 50 characters in compact mode

## Changes
- `src/hooks/use-input.ts` — Added `displayValue`, `isMultiLine`, `lineCount`, `clearMultiLine` to hook
- `src/components/InputArea.tsx` — Added `MultiLineKeyHandler` component and compact display mode
- `src/components/App.tsx` — Pass new props to InputArea
- `src/index.tsx` — Pass new props from useInput to App

## Test plan
- [x] `tests/hooks/use-input.test.tsx` — 7 new tests for multi-line detection, display, clear
- [x] `tests/components/input-area.test.tsx` — 3 new tests for compact display and hints
- [x] `tests/components/app.test.tsx` — Updated with new props
- [x] All 201 tests pass (2 pre-existing flaky RPC tests excluded)

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)